### PR TITLE
Add missing const modifier

### DIFF
--- a/sanjuuni.cpp
+++ b/sanjuuni.cpp
@@ -1545,7 +1545,7 @@ int main(int argc, const char * argv[]) {
 
     AVFormatContext * format_ctx = NULL;
     AVCodecContext * video_codec_ctx = NULL, * audio_codec_ctx = NULL;
-    AVCodec * video_codec = NULL, * audio_codec = NULL;
+    const AVCodec * video_codec = NULL, * audio_codec = NULL;
     SwsContext * resize_ctx = NULL;
     SwrContext * resample_ctx = NULL;
     int error, video_stream = -1, audio_stream = -1;


### PR DESCRIPTION
Fixes a compilation error on GCC 11.

---

I did look at adding `-Wall -Wextra -Wpedantic` but there were too many errors to fix. C truly is a terrible language.